### PR TITLE
[s3] Upload file directly so AWS SDK can properly retry

### DIFF
--- a/src/main/kotlin/com/jetbrains/notary/NotaryClientV2.kt
+++ b/src/main/kotlin/com/jetbrains/notary/NotaryClientV2.kt
@@ -3,7 +3,6 @@ package com.jetbrains.notary
 import com.amazonaws.auth.AWSStaticCredentialsProvider
 import com.amazonaws.auth.BasicSessionCredentials
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
-import com.amazonaws.services.s3.model.ObjectMetadata
 import com.amazonaws.services.s3.model.PutObjectRequest
 import com.amazonaws.services.s3.model.PutObjectResult
 import com.jetbrains.notary.auth.AppStoreConnectAPIKey
@@ -22,8 +21,6 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import java.nio.file.Path
-import kotlin.io.path.fileSize
-import kotlin.io.path.inputStream
 import kotlin.time.Duration.Companion.minutes
 
 @OptIn(ExperimentalSerializationApi::class)
@@ -95,15 +92,10 @@ class NotaryClientV2(
         // Thanks to the folks that built https://github.com/indygreg/PyOxidizer, we got it's us-west-2...
         s3Region: String = "us-west-2",
     ): PutObjectResult? {
-        val inputStream = filepath.inputStream().buffered()
-        val metadata = ObjectMetadata().also {
-            it.contentLength = filepath.fileSize()
-        }
         val request = PutObjectRequest(
             attributes.bucket,
             attributes.`object`,
-            inputStream,
-            metadata,
+            filepath.toFile(),
         )
         val credentials = BasicSessionCredentials(
             attributes.awsAccessKeyId,


### PR DESCRIPTION
I've encountered the following issue on CI:

```
com.amazonaws.ResetException: The request to the service failed with a retryable reason,
  but resetting the request input stream has failed.
    ... If the request involves an input stream, the maximum stream buffer
    size can be configured via request.getRequestClientOptions().setReadLimit(int)
  Caused by: java.io.IOException: Resetting to invalid mark
      at java.base/java.io.BufferedInputStream.reset
      at com.amazonaws.services.s3.AmazonS3Client.putObject
      at com.jetbrains.notary.NotaryClientV2.uploadSoftware(NotaryClientV2.kt:118)
      at com.jetbrains.notary.extensions.NotarizeKt.notarize(notarize.kt:93)
      at com.jetbrains.toolbox.bazel.distribution.framework.notarization.NotarizationFramework.notarize(NotarizationFramework.kt:111)
      at com.jetbrains.toolbox.distribution.bazel.AppMacOsReleasePipeline.run(AppMacOsReleasePipeline.kt:131)
```

<hr/>
AI analysis of the issue:

1. The notary library (org.jetbrains:apple-notary-api-kotlin-client:2.0.1) uploads the DMG to Apple's S3-backed notary service via AWS SDK v1.
2. AWS hit a transient retryable network error mid-upload.
3. AWS SDK tried to retry by reset()-ing the input stream, but the underlying BufferedInputStream's mark had already expired — the 203 MB DMG is far larger than the default readLimit (128 KB).
4. The retry threw ResetException, the JVM exited with code 1, and the build failed.

<hr/>

I went with using a proper File API that is supported by AWS SDK instead of managing our own stream. As a bonus, this fixes a leaked/never closed stream. 